### PR TITLE
chore: Fix ESLint configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: mcr.microsoft.com/playwright:v1.47.1-noble
+      image: mcr.microsoft.com/playwright:v1.49.1-noble
 
     steps:
       - name: Checkout repository 🛎️

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,11 +25,8 @@ export default tseslint.config(
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       globals: {
-        ...globals.browser, // Common browser globals (window, document, etc.)
-        ...globals.es2021, // ECMAScript 2021 features
-        React: 'readonly', // React global (useful for JSX)
-        JSX: 'readonly', // JSX global (useful for TypeScript with JSX)
-        vi: 'readonly', // Vitest global (useful for Vitest for testing)
+        ...globals.browser,
+        ...globals.es2021,
       },
       parser: tseslint.parser,
       parserOptions: {
@@ -61,14 +58,13 @@ export default tseslint.config(
       },
     },
     rules: {
-      ...reactPlugin.configs.recommended.rules,
-      ...reactPlugin.configs['jsx-runtime'].rules,
       ...reactHooksPlugin.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'simple-import-sort/exports': 'error',
       'no-console': 'error',
       'prettier/prettier': 'error',
       'react-hooks/rules-of-hooks': 'error',
-      'no-multiple-empty-lines': 'error',
+      'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0, maxBOF: 0 }],
       'padding-line-between-statements': [
         'error',
         { blankLine: 'always', prev: '*', next: 'if' },
@@ -143,16 +139,21 @@ export default tseslint.config(
           extensions: ['.tsx', '.mdx'],
         },
       ],
-      'react/jsx-uses-react': 'off',
       'react/jsx-key': [
         'error',
         {
           checkFragmentShorthand: true,
         },
       ],
-      'react/react-in-jsx-scope': 'off',
       'react-hooks/exhaustive-deps': 'error',
       'eol-last': ['error', 'always'],
+      // Workaround: this version of @typescript-eslint crashes when these rules receive no options object
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        { allowShortCircuit: false, allowTernary: false, allowTaggedTemplates: false },
+      ],
+      '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
+      '@typescript-eslint/no-empty-function': 'off',
     },
   },
   {
@@ -165,6 +166,17 @@ export default tseslint.config(
     files: ['**/*.types.ts', 'src/types/**/*.*'],
     rules: {
       'max-lines': 'off',
+    },
+  },
+  {
+    files: ['**/*.{spec,test}.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        vi: 'readonly',
+      },
+    },
+    rules: {
+      'react-refresh/only-export-components': 'off',
     },
   }
 );


### PR DESCRIPTION
Adjust ESLint config after package upgrades

## Summary by Sourcery

Adjust ESLint configuration to align with upgraded packages and introduce test-specific linting overrides.

Enhancements:
- Refine global definitions to rely on standard browser and ES2021 globals instead of custom React and test globals.
- Tighten linting rules, including stricter control of empty lines, import/export sorting, and additional TypeScript-specific rules with safe option defaults.
- Add test-file-specific ESLint overrides to register Vitest globals and relax React Refresh export restrictions.
- Add a local Claude configuration file for editor/assistant tooling.