### PR TITLE
chore: Optimize Docker and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     # Important conditions, since all following jobs depend on this job and do not check for these conditions again
     # Run for any push event or PR but skip draft PRs
     if: >-
@@ -75,6 +78,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repository 🛎️
         uses: actions/checkout@v4
@@ -90,10 +96,15 @@ jobs:
   unit-tests:
     name: Unit Tests (Jest/RTL)
 
+    # Unit tests run via Vitest against source files directly — no build output needed.
+    # Running in parallel with build saves the full build time before tests start.
     needs:
-      - build
+      - linters
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository 🛎️
@@ -117,6 +128,9 @@ jobs:
       - build
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['develop', 'main']
   pull_request:
-    branches: ['develop']
+    branches: ['develop', 'main']
     types:
       - opened
       - reopened

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
 FROM node:22-alpine
 
-ENV APP_HOME /app
+ENV APP_HOME=/app
 
-RUN mkdir $APP_HOME
-WORKDIR $APP_HOME
-
-COPY package* ./
-RUN npm install
-
-# Add `/app/node_modules/.bin` to $PATH
-ENV PATH $APP_HOME/node_modules/.bin:$PATH
-
-# Create a new user with least privileges
+# Create non-root user before installing dependencies
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-# Create necessary directories and set permissions
-RUN mkdir -p $APP_HOME/logs $APP_HOME/tmp \
-  && chown -R appuser:appgroup $APP_HOME
+WORKDIR $APP_HOME
+RUN chown appuser:appgroup $APP_HOME
 
-# Switch to the new user
 USER appuser
 
-COPY --chown=appuser:appgroup . $APP_HOME
+COPY --chown=appuser:appgroup package*.json ./
+
+RUN npm ci
+
+# Add node_modules/.bin to PATH
+ENV PATH=$APP_HOME/node_modules/.bin:$PATH
+
+COPY --chown=appuser:appgroup . .
 
 EXPOSE 3001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
           # - add other files and folders to not sync with container
         - action: rebuild
           path: package.json
+        - action: rebuild
+          path: package-lock.json
     environment:
       - PORT=3001
       - BROWSER=none


### PR DESCRIPTION
## Summary

- **Dockerfile**: Create non-root user _before_ installing dependencies, eliminating the slow `chown -R` over `node_modules`. Switch to `npm ci` for reproducible image builds. Remove redundant `mkdir` (WORKDIR creates the dir) and unused `logs/`/`tmp/` dirs. Use modern `ENV KEY=VALUE` syntax.
- **docker-compose**: Add `package-lock.json` as a rebuild trigger alongside `package.json` so lockfile-only changes correctly trigger a container rebuild.
- **CI**: Run `unit-tests` in parallel with `build` — Vitest runs against source files directly and never needed the build output, saving the full build time from the unit test critical path. Add `permissions: contents: read` to all jobs (least-privilege).
- **CodeQL**: Extend PR scanning to `main` branch — previously PRs targeting `main` bypassed security scanning entirely.

## Test plan

- [ ] `docker-compose up --watch` starts correctly and hot-reload works
- [ ] Changing `package-lock.json` without touching `package.json` triggers a container rebuild
- [ ] CI pipeline: unit-tests and build jobs run in parallel after linters
- [ ] CodeQL scan triggers on PRs to both `develop` and `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize Docker image, local dev rebuild behavior, and CI/security workflows for faster, safer pipelines.

Enhancements:
- Rework Dockerfile to use a non-root user during dependency installation, rely on npm ci, and simplify PATH and directory setup for leaner, more reproducible images.
- Adjust docker-compose file-watch configuration so changes to package-lock.json also trigger container rebuilds.
- Update CI workflow so unit tests depend only on linters instead of the build, allowing tests to run in parallel with the build while granting least-privilege contents: read permissions to all jobs.
- Expand CodeQL PR analysis to include pull requests targeting the main branch in addition to develop.